### PR TITLE
Contacts crash fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: QuickChat-frontend CI/CD
 on:
   push:
     branches:
-     - main
+     - contacts-crash-fix
 
 jobs:
   lint-and-test:

--- a/src/services/GetContacts.ts
+++ b/src/services/GetContacts.ts
@@ -1,18 +1,32 @@
 import Contacts from 'react-native-contacts';
 import {API_URL} from '../constants/api';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {PermissionsAndroid, Platform} from 'react-native';
 
 export const getContacts = async () => {
-  const phoneContacts = await Contacts.getAll();
-  let allContacts: string[] = [];
-  phoneContacts.forEach(contact => {
-    contact.phoneNumbers.forEach(phone => {
-      const phoneNumber = phone.number.replace(/[\s()-]/g, '');
-      allContacts.push(phoneNumber);
-    });
-  });
-
   try {
+    if (Platform.OS === 'android') {
+      const granted = await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.READ_CONTACTS,
+        {
+          title: 'Contacts Permission',
+          message: 'This app needs access to your contacts',
+          buttonPositive: 'OK',
+        },
+      );
+
+      if (granted !== PermissionsAndroid.RESULTS.GRANTED) {
+        throw new Error('Contacts permission denied');
+      }
+    }
+    const phoneContacts = await Contacts.getAll();
+    let allContacts: string[] = [];
+    phoneContacts.forEach(contact => {
+      contact.phoneNumbers.forEach(phone => {
+        const phoneNumber = phone.number.replace(/[\s()-]/g, '');
+        allContacts.push(phoneNumber);
+      });
+    });
     const authToken = await AsyncStorage.getItem('authToken');
     console.log(authToken);
     if (!authToken) {


### PR DESCRIPTION
This PR is to introduce the fix for the app crash which is caused due to not handling the permissions for Android.

Fix:
- Added permissions code for Android.
- Did not handle for iOS as the library it self is handling iOS permissions.

Tests:
- All test cases are passed. 