### PR TITLE
Refactor encryption/decryption functions from secretbox to box

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - fix/encryption-decryption
+
 jobs:
   lint-and-test:
     uses: ./.github/workflows/lint-and-test.yml

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -118,6 +118,8 @@ jest.mock('react-native-libsodium', () => ({
   randombytes_buf: jest.fn(() => new Uint8Array(24).fill(3)),
   from_base64: jest.fn((input: string) => Uint8Array.from(Buffer.from(input, 'base64'))),
   crypto_secretbox_open_easy: jest.fn(() => new Uint8Array(Buffer.from('secret-key'))),
+  crypto_box_open_easy: jest.fn(() => Uint8Array.from(Buffer.from('my-private-key')),),
+  crypto_box_easy: jest.fn(() => new Uint8Array(64).fill(1)),
 }));
 
 test('runs useEffect on mount and sets language', async () => {

--- a/src/services/KeyEncryption.ts
+++ b/src/services/KeyEncryption.ts
@@ -9,9 +9,10 @@ export const keyEncryption = async ({
   try {
     const nonce = await Sodium.randombytes_buf(24);
     const passwordBytes = new TextEncoder().encode(password);
+    const privateKeyBytes = await Sodium.from_base64(privateKey);
     const passwordBuffer = await Sodium.crypto_generichash(32, passwordBytes);
     const encryptedPrivateKey = await Sodium.crypto_secretbox_easy(
-      privateKey,
+      privateKeyBytes,
       nonce,
       passwordBuffer,
     );

--- a/src/services/MessageDecryption.ts
+++ b/src/services/MessageDecryption.ts
@@ -2,27 +2,30 @@ import Sodium from 'react-native-libsodium';
 
 export const messageDecryption = async ({
   encryptedMessage,
-  sharedKey,
+  myPrivateKey,
+  senderPublicKey,
 }: {
   encryptedMessage: string;
-  sharedKey: string;
+  myPrivateKey: string;
+  senderPublicKey: string;
 }) => {
   try {
     const {nonce, encrypted} = JSON.parse(encryptedMessage);
 
-  const nonceBytes = Sodium.from_base64(nonce);
-  const encryptedBytes = Sodium.from_base64(encrypted);
-  const keyBytes = Sodium.from_base64(sharedKey);
+    const nonceBytes = await Sodium.from_base64(nonce);
+    const encryptedBytes = await Sodium.from_base64(encrypted);
+    const myPrivateKeyBytes = await Sodium.from_base64(myPrivateKey);
+    const senderPublicKeyBytes = await Sodium.from_base64(senderPublicKey);
 
-  const decryptedMessage = await Sodium.crypto_secretbox_open_easy(
-    encryptedBytes,
-    nonceBytes,
-    keyBytes,
-  );
-
-  return Sodium.to_base64(decryptedMessage);
+    const decryptedBytes = await Sodium.crypto_box_open_easy(
+      encryptedBytes,
+      nonceBytes,
+      senderPublicKeyBytes,
+      myPrivateKeyBytes,
+    );
+    return Sodium.to_string(decryptedBytes);
   } catch (error) {
- throw new Error(
+    throw new Error(
       `Error while decrypting the message: ${(error as Error).message}`,
     );
   }

--- a/src/services/MessageEncryption.ts
+++ b/src/services/MessageEncryption.ts
@@ -2,22 +2,30 @@ import Sodium from 'react-native-libsodium';
 
 export const messageEncryption = async ({
   message,
-  secretKey,
+  myPrivateKey,
+  recipientPublicKey,
 }: {
   message: string;
-  secretKey: string;
+  myPrivateKey: string;
+  recipientPublicKey: string;
 }) => {
   try {
     const nonce = await Sodium.randombytes_buf(24);
-    const keyBytes = Sodium.from_base64(secretKey);
-    const encryptedMessage = await Sodium.crypto_secretbox_easy(
-      message,
+    const messageBytes = new TextEncoder().encode(message);
+    const myPrivateKeyBytes = await Sodium.from_base64(myPrivateKey);
+    const recipientPublicKeyBytes = await Sodium.from_base64(
+      recipientPublicKey,
+    );
+
+    const encryptedMessage = await Sodium.crypto_box_easy(
+      messageBytes,
       nonce,
-      keyBytes,
+      recipientPublicKeyBytes,
+      myPrivateKeyBytes,
     );
     return JSON.stringify({
-      nonce: Sodium.to_base64(nonce),
-      encrypted: Sodium.to_base64(encryptedMessage),
+      nonce: await Sodium.to_base64(nonce),
+      encrypted: await Sodium.to_base64(encryptedMessage),
     });
   } catch (error) {
     throw new Error(

--- a/src/services/__tests__/KeyEncryption.test.ts
+++ b/src/services/__tests__/KeyEncryption.test.ts
@@ -6,6 +6,9 @@ jest.mock('react-native-libsodium', () => ({
   to_base64: jest.fn((input: Uint8Array) =>
     Buffer.from(input).toString('base64'),
   ),
+  from_base64: jest.fn((input: string) =>
+    Uint8Array.from(Buffer.from(input, 'base64')),
+  ),
   crypto_generichash: jest.fn(() => new Uint8Array(32).fill(1)),
   crypto_secretbox_easy: jest.fn(() => new Uint8Array(64).fill(2)),
   randombytes_buf: jest.fn(() => new Uint8Array(24).fill(3)),
@@ -22,6 +25,7 @@ describe('keyEncryption', () => {
 
     expect(typeof parsed.nonce).toBe('string');
     expect(typeof parsed.encrypted).toBe('string');
+    expect(Sodium.from_base64).toHaveBeenCalled();
     expect(Sodium.randombytes_buf).toHaveBeenCalledWith(24);
     expect(Sodium.crypto_generichash).toHaveBeenCalled();
   });

--- a/src/services/__tests__/MessageDecryption.test.ts
+++ b/src/services/__tests__/MessageDecryption.test.ts
@@ -1,16 +1,23 @@
 import Sodium from 'react-native-libsodium';
-import { messageDecryption } from '../messageDecryption';
+import {messageDecryption} from '../messageDecryption';
 
 jest.mock('react-native-libsodium', () => ({
-  from_base64: jest.fn((input: string) => Uint8Array.from(Buffer.from(input, 'base64'))),
-    to_base64: jest.fn((input: Uint8Array) =>
+  from_base64: jest.fn((input: string) =>
+    Uint8Array.from(Buffer.from(input, 'base64')),
+  ),
+  to_base64: jest.fn((input: Uint8Array) =>
     Buffer.from(input).toString('base64'),
   ),
-  crypto_secretbox_open_easy: jest.fn(() =>  Uint8Array.from(Buffer.from('shared-key'))),
+  crypto_box_open_easy: jest.fn(() =>
+    Uint8Array.from(Buffer.from('my-private-key')),
+  ),
+  to_string: jest.fn((input: Uint8Array) =>
+    Buffer.from(input).toString('utf-8'),
+  ),
 }));
 
 describe('Message Decryption', () => {
- it('should decrypt the message using shared key', async () => {
+  it('should decrypt the message using shared key', async () => {
     const encryptedMessageJson = JSON.stringify({
       nonce: Buffer.from('nonce-value').toString('base64'),
       encrypted: Buffer.from('ciphermessage').toString('base64'),
@@ -18,26 +25,28 @@ describe('Message Decryption', () => {
 
     const result = await messageDecryption({
       encryptedMessage: encryptedMessageJson,
-      sharedKey: 'shared-key',
+      myPrivateKey: 'my-private-key',
+      senderPublicKey: 'sender-public-key',
     });
 
-    expect(result).toBe(Buffer.from('shared-key').toString('base64'));
-    expect(Sodium.crypto_secretbox_open_easy).toHaveBeenCalled();
+    expect(result).toBe('my-private-key');
+    expect(Sodium.crypto_box_open_easy).toHaveBeenCalled();
   });
 
   it('should throw an error when decryption fails', async () => {
-      (Sodium.crypto_secretbox_open_easy as jest.Mock).mockImplementationOnce(() => {
-        throw new Error('Decryption failed');
-      });
-
-      await expect(
-        messageDecryption({
-          encryptedMessage: JSON.stringify({
-            nonce: Buffer.from('nonce-value').toString('base64'),
-            encrypted: Buffer.from('ciphermessage').toString('base64'),
-          }),
-          sharedKey: 'shared-key',
-        })
-      ).rejects.toThrow('Error while decrypting the message: Decryption failed');
+    (Sodium.crypto_box_open_easy as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('Decryption failed');
     });
+
+    await expect(
+      messageDecryption({
+        encryptedMessage: JSON.stringify({
+          nonce: Buffer.from('nonce-value').toString('base64'),
+          encrypted: Buffer.from('ciphermessage').toString('base64'),
+        }),
+        myPrivateKey: 'my-private-key',
+        senderPublicKey: 'sender-public-key',
+      }),
+    ).rejects.toThrow('Error while decrypting the message: Decryption failed');
+  });
 });

--- a/src/services/__tests__/RegisterUser.test.ts
+++ b/src/services/__tests__/RegisterUser.test.ts
@@ -11,6 +11,9 @@ jest.mock('react-native-libsodium', () => ({
   to_base64: jest.fn((input: Uint8Array) =>
     Buffer.from(input).toString('base64'),
   ),
+  from_base64: jest.fn((input: string) =>
+    Uint8Array.from(Buffer.from(input, 'base64')),
+  ),
   crypto_generichash: jest.fn(() => new Uint8Array(32).fill(1)),
   crypto_secretbox_easy: jest.fn(() => new Uint8Array(64).fill(2)),
   randombytes_buf: jest.fn(() => new Uint8Array(24).fill(3)),


### PR DESCRIPTION
This PR updates the message encryption and decryption logic to use libsodium's crypto_box and crypto_box_open instead of crypto_secretbox. This improves the use of public-key cryptography, enabling secure sender-receiver communication without pre-shared keys.

- Replaced crypto_secretbox_easy with crypto_box_easy in encryption.
- Replaced crypto_secretbox_open_easy with crypto_box_open_easy in decryption.
- Updated all relevant mocks in unit tests to reflect the use of crypto_box APIs.

