### PR TITLE
Implement screen to render unread chats

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - fix/ui-styling-multiple-devices
+      - feature/unread-chats
 
 jobs:
   lint-and-test:

--- a/src/i18n/translations/english/home.json
+++ b/src/i18n/translations/english/home.json
@@ -3,5 +3,6 @@
     "Profile":"Profile",
     "Unread Chats":"Unread Chats",
     "Edit Profile":"Edit Profile",
-    "No messages yet? That just means the best one is about to be sent—by you!":"No messages yet? That just means the best one is about to be sent—by you!"
+    "No messages yet? That just means the best one is about to be sent—by you!":"No messages yet? That just means the best one is about to be sent—by you!",
+    "EmptyUnreadMessage":"You are all caught up!\nNo unread messages."
 }

--- a/src/i18n/translations/telugu/home.json
+++ b/src/i18n/translations/telugu/home.json
@@ -4,5 +4,6 @@
     "Unread Chats":"చదవని చాట్‌లు",
     "Quick Chat":"క్విక్ చాట్",
     "Edit Profile":"ప్రొఫైల్ సవరించండి",
-    "No messages yet? That just means the best one is about to be sent—by you!":"ఇంకా ఒక్క మెసేజ్ కూడా లేదా? అద్భుతమైనదే నువ్వే పంపబోతున్నావేమో!"
+    "No messages yet? That just means the best one is about to be sent—by you!":"ఇంకా ఒక్క మెసేజ్ కూడా లేదా? అద్భుతమైనదే నువ్వే పంపబోతున్నావేమో!",
+    "EmptyUnreadMessage": "మీరు అన్నీ చదివారు!\nచదవని సందేశాలు లేవు."
 }

--- a/src/navigation/stack/UnreadStacks.test.tsx
+++ b/src/navigation/stack/UnreadStacks.test.tsx
@@ -1,0 +1,56 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { store } from '../../store/store';
+import { UnreadStacks } from './UnreadStacks';
+
+jest.mock('../../screens/UnreadChats/UnreadChats', () => {
+    const { Text, Button } = require('react-native');
+    return {
+        UnreadChats: ({ navigation }: any) => (
+            <>
+                <Text>Unread Chats Screen</Text>
+                <Button
+                    title="Go to Individual Chat"
+                    onPress={() => navigation.navigate('individualChat')}
+                />
+            </>
+        ),
+    };
+});
+
+jest.mock('../../screens/IndividualChat/IndividualChat', () => {
+    const { Text } = require('react-native');
+    return {
+        IndividualChat: () => <Text>Individual Chat Screen</Text>,
+    };
+});
+
+describe('UnreadStacks Navigation', () => {
+    const renderWithProviders = () =>
+        render(
+            <Provider store={store}>
+                <NavigationContainer>
+                    <UnreadStacks />
+                </NavigationContainer>
+            </Provider>
+        );
+
+    it('renders the UnreadChats screen initially', async () => {
+        const { getByText } = renderWithProviders();
+
+        await waitFor(() => {
+            expect(getByText('Unread Chats Screen')).toBeTruthy();
+        });
+    });
+
+    it('navigates to IndividualChat screen on button press', async () => {
+        const { getByText } = renderWithProviders();
+
+        fireEvent.press(getByText('Go to Individual Chat'));
+
+        await waitFor(() => {
+            expect(getByText('Individual Chat Screen')).toBeTruthy();
+        });
+    });
+});

--- a/src/navigation/stack/UnreadStacks.tsx
+++ b/src/navigation/stack/UnreadStacks.tsx
@@ -1,0 +1,23 @@
+
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { IndividualChat } from '../../screens/IndividualChat/IndividualChat';
+import { UnreadChats } from '../../screens/UnreadChats/UnreadChats';
+import { UnreadStackParamList } from '../../types/usenavigation.type';
+
+export const UnreadStacks = () => {
+const Stack = createNativeStackNavigator<UnreadStackParamList>();
+    return (
+        <Stack.Navigator initialRouteName={'unread'}>
+            <Stack.Screen
+                name="unread"
+                component={UnreadChats}
+                options={{ headerShown: false }}
+            />
+            <Stack.Screen
+                name="individualChat"
+                component={IndividualChat}
+                options={{ headerShown: false }}
+            />
+        </Stack.Navigator>
+    );
+};

--- a/src/navigation/tab/HomeTabs.tsx
+++ b/src/navigation/tab/HomeTabs.tsx
@@ -2,7 +2,6 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { getFocusedRouteNameFromRoute } from '@react-navigation/native';
 import { Image, View } from 'react-native';
 
-import { Unread } from '../../screens/Unread/Unread';
 import { HomeStacks } from '../stack/HomeStacks';
 import { ProfileStack } from '../stack/ProfileStacks';
 
@@ -13,10 +12,11 @@ import { User } from '../../screens/Profile/Profile';
 import { newSocket, socketConnection } from '../../socket/socket';
 import { useThemeColors } from '../../themes/colors';
 import { useImagesColors } from '../../themes/images';
+import { UnreadStacks } from '../stack/UnreadStacks.tsx';
 import { styles } from './HomeTabs.styles';
 
-const HomeTabIcon = ({focused}: {focused: boolean}) => {
-  const {tabHome} = useImagesColors();
+const HomeTabIcon = ({ focused }: { focused: boolean }) => {
+  const { tabHome } = useImagesColors();
   return (
     <View style={styles.iconContainer}>
       {!focused ? (
@@ -31,8 +31,8 @@ const HomeTabIcon = ({focused}: {focused: boolean}) => {
   );
 };
 
-const UnreadTabIcon = ({focused}: {focused: boolean}) => {
-  const {tabUnread} = useImagesColors();
+const UnreadTabIcon = ({ focused }: { focused: boolean }) => {
+  const { tabUnread } = useImagesColors();
   return (
     <View style={styles.iconContainer}>
       {!focused ? (
@@ -47,8 +47,8 @@ const UnreadTabIcon = ({focused}: {focused: boolean}) => {
   );
 };
 
-const ProfileTabIcon = ({focused}: {focused: boolean}) => {
-  const {tabProfile} = useImagesColors();
+const ProfileTabIcon = ({ focused }: { focused: boolean }) => {
+  const { tabProfile } = useImagesColors();
   return (
     <View style={styles.iconContainer}>
       {!focused ? (
@@ -79,7 +79,7 @@ export const HomeTabs = () => {
   }, []);
   const Tab = createBottomTabNavigator();
   const colors = useThemeColors();
-  const {t} = useTranslation('home');
+  const { t } = useTranslation('home');
   return (
     <Tab.Navigator
       screenOptions={{
@@ -103,7 +103,7 @@ export const HomeTabs = () => {
       <Tab.Screen
         name="homeStacks"
         component={HomeStacks}
-        options={({route}) => {
+        options={({ route }) => {
           const routeName = getFocusedRouteNameFromRoute(route) ?? 'home';
           const hideTabBar = routeName === 'individualChat';
           return {
@@ -121,14 +121,14 @@ export const HomeTabs = () => {
       />
       <Tab.Screen
         name="unread"
-        component={Unread}
+        component={UnreadStacks}
         options={{
           tabBarIcon: UnreadTabIcon,
           tabBarLabel: t('Unread Chats'),
-          headerStyle: {backgroundColor: colors.background},
+          headerStyle: { backgroundColor: colors.background },
           headerTitleAlign: 'center',
           headerTitle: t('Quick Chat'),
-          headerTitleStyle: {color: colors.text},
+          headerTitleStyle: { color: colors.text },
         }}
       />
       <Tab.Screen
@@ -139,7 +139,7 @@ export const HomeTabs = () => {
           tabBarIcon: ProfileTabIcon,
           tabBarLabel: t('Profile'),
         }}
-        listeners={({navigation}) => ({
+        listeners={({ navigation }) => ({
           tabPress: event => {
             event.preventDefault();
             navigation.navigate('profileStack', {

--- a/src/screens/AllChats/AllChats.styles.ts
+++ b/src/screens/AllChats/AllChats.styles.ts
@@ -1,6 +1,7 @@
-import { StyleSheet } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
 import { Colors } from '../../themes/colors';
 
+const { height } = Dimensions.get('window');
 export const getStyles = (colors: Colors) =>
   StyleSheet.create({
     container: {
@@ -17,5 +18,14 @@ export const getStyles = (colors: Colors) =>
       bottom: 20,
       right: 20,
       zIndex: 10,
+    },
+    unreadtext: {
+      color: colors.gray,
+      fontSize: 18,
+      fontWeight: 'bold',
+    },
+    noMessagesContainer: {
+      alignSelf: 'center',
+      marginTop: height * 0.39,
     },
   });

--- a/src/screens/Unread/Unread.test.tsx
+++ b/src/screens/Unread/Unread.test.tsx
@@ -1,9 +1,0 @@
-import {render, screen} from '@testing-library/react-native';
-import { Unread } from './Unread';
-
-describe('Profile Screen', () => {
-  it('renders the logo image', () => {
-    render(<Unread />);
-    expect(screen.getByText('Hello unread')).toBeTruthy();
-  });
-});

--- a/src/screens/Unread/Unread.tsx
+++ b/src/screens/Unread/Unread.tsx
@@ -1,9 +1,0 @@
-import {Text, View} from 'react-native';
-
-export const Unread = () => {
-  return (
-    <View>
-      <Text>Hello unread</Text>
-    </View>
-  );
-};

--- a/src/screens/UnreadChats/UnreadChats.test.tsx
+++ b/src/screens/UnreadChats/UnreadChats.test.tsx
@@ -1,0 +1,250 @@
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { numberNameIndex } from '../../helpers/nameNumberIndex';
+import { getAllChats } from '../../services/GetAllChats';
+import { store } from '../../store/store';
+import { UnreadChats, Chat } from './UnreadChats';
+
+const mockChats = [
+  {
+    chatId: '1',
+    contactName: 'User A',
+    contactProfilePic: null,
+    lastMessageStatus: 'delivered',
+    lastMessageText: 'How are you doing?',
+    lastMessageTimestamp: '2025-04-10T11:30:00Z',
+    lastMessageType: 'ReceivedMessage',
+    phoneNumber: '8978363862',
+    unreadCount: 3,
+    publicKey: '',
+  },
+];
+
+const emptyChats: Chat[] = [];
+
+const mockNavigate = jest.fn();
+const mockReplace = jest.fn();
+const mockSetOptions = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      replace: mockReplace,
+      setOptions: mockSetOptions,
+    }),
+  };
+});
+
+jest.mock('react-native-encrypted-storage', () => ({
+  clear: jest.fn(),
+  getItem: jest.fn().mockResolvedValue('mock-private-key'),
+}));
+
+jest.mock('../../services/MessageDecryption', () => ({
+  messageDecryption: jest.fn().mockResolvedValue('Decrypted Message'),
+}));
+
+jest.mock('../../services/MessageDecryption', () => ({
+  messageDecryption: jest.fn().mockImplementation(({ encryptedMessage }) => {
+    if (encryptedMessage === 'Hello there!') {
+      return '✓Hello there!';
+    }
+    if (encryptedMessage === 'How are you doing?') {
+      return '✓✓How are you doing?';
+    }
+    return encryptedMessage;
+  }),
+}));
+
+jest.useFakeTimers();
+
+jest.mock('../../helpers/nameNumberIndex', () => ({
+  numberNameIndex: jest.fn(),
+}));
+
+jest.mock('../../services/GetAllChats', () => ({
+  getAllChats: jest.fn(),
+}));
+
+jest.mock('../../helpers/normalisePhoneNumber', () => ({
+  normalise: jest.fn(),
+}));
+
+describe('Unread chats component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-04-24T12:00:00').getTime());
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should logout and redirect if numberNameIndex returns null', async () => {
+    (numberNameIndex as jest.Mock).mockResolvedValue(null);
+
+    await waitFor(() => {
+      render(
+        <Provider store={store}>
+          <NavigationContainer>
+            <UnreadChats />
+          </NavigationContainer>
+        </Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      const state = store.getState();
+      expect(state.registration.alertType).toBe('error');
+      expect(state.registration.alertMessage).toBe('Please login again.');
+      jest.advanceTimersByTime(1000);
+      expect(mockReplace).toHaveBeenCalledWith('login');
+    });
+  });
+
+  it('should logout and redirect to login on 401 response', async () => {
+    (numberNameIndex as jest.Mock).mockResolvedValue({});
+    (getAllChats as jest.Mock).mockResolvedValue({ status: 401 });
+
+    await waitFor(() => {
+      render(
+        <Provider store={store}>
+          <NavigationContainer>
+            <UnreadChats />
+          </NavigationContainer>
+        </Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      const state = store.getState();
+      expect(state.registration.alertType).toBe('error');
+      expect(state.registration.alertMessage).toBe('Please login again.');
+      jest.advanceTimersByTime(1000);
+      expect(mockReplace).toHaveBeenCalledWith('login');
+    });
+  });
+
+  it('should render text when no chats count is less than zero', async () => {
+    (numberNameIndex as jest.Mock).mockResolvedValue({});
+    (getAllChats as jest.Mock).mockResolvedValue({
+      status: 200,
+      data: { chats: emptyChats },
+    });
+
+    await waitFor(() => {
+      render(
+        <Provider store={store}>
+          <NavigationContainer>
+            <UnreadChats />
+          </NavigationContainer>
+        </Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('EmptyUnreadMessage'),
+      ).toBeTruthy();
+    });
+  });
+
+  it('should render unread chats with correct information', async () => {
+    (numberNameIndex as jest.Mock).mockResolvedValue({});
+
+    (getAllChats as jest.Mock).mockResolvedValue({
+      status: 200,
+      data: { chats: mockChats },
+    });
+
+    await waitFor(() => {
+      render(
+        <Provider store={store}>
+          <NavigationContainer>
+            <UnreadChats />
+          </NavigationContainer>
+        </Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      const profileImage = screen.getAllByAccessibilityHint('profile-image');
+      expect(profileImage.length).toBe(1);
+      expect(screen.getByText('8978363862')).toBeTruthy();
+      expect(screen.getByText('Apr 10, 2025')).toBeTruthy();
+      expect(screen.getByText('3')).toBeTruthy();
+      expect(screen.getByText(/How are you doing\?/)).toBeTruthy();
+    });
+  });
+
+  it('should navigate to individual chat when chatbox is pressed', async () => {
+    (numberNameIndex as jest.Mock).mockResolvedValue({});
+
+    (getAllChats as jest.Mock).mockResolvedValue({
+      status: 200,
+      data: { chats: mockChats },
+    });
+
+    await waitFor(() => {
+      render(
+        <Provider store={store}>
+          <NavigationContainer>
+            <UnreadChats />
+          </NavigationContainer>
+        </Provider>,
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText('8978363862')).toBeTruthy();
+    });
+    fireEvent.press(screen.getByText('8978363862'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('individualChat', {
+      user: {
+        name: '8978363862',
+        profilePicture: null,
+        phoneNumber: '8978363862',
+        isBlocked: false,
+        publicKey: '',
+        onBlockStatusChange: expect.any(Function),
+      },
+    });
+  });
+
+  it('should not set chats if response status is not 200', async () => {
+    (numberNameIndex as jest.Mock).mockResolvedValue({});
+
+    (getAllChats as jest.Mock).mockResolvedValue({
+      status: 500,
+      data: { chats: mockChats },
+    });
+
+    await waitFor(() => {
+      render(
+        <Provider store={store}>
+          <NavigationContainer>
+            <UnreadChats />
+          </NavigationContainer>
+        </Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('EmptyUnreadMessage'),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/src/screens/UnreadChats/UnreadChats.tsx
+++ b/src/screens/UnreadChats/UnreadChats.tsx
@@ -18,7 +18,6 @@ import {
   setAlertType,
   setAlertVisible,
 } from '../../store/slices/registrationSlice';
-import { setUnreadCount } from '../../store/slices/unreadChatSlice';
 import { useThemeColors } from '../../themes/colors';
 import { NavigationProps, UnreadStacKProps } from '../../types/usenavigation.type';
 import { getStyles } from '../AllChats/AllChats.styles';
@@ -105,12 +104,6 @@ export const UnreadChats = () => {
             const unreadChats = allChats.filter((chat: { unreadCount: number; }) => chat.unreadCount > 0);
 
             setChats(unreadChats);
-
-            const totalUnread = unreadChats.reduce(
-              (sum: number, chat: { unreadCount: number; }) => sum + (chat.unreadCount || 0),
-              0,
-            );
-            dispatch(setUnreadCount(totalUnread));
           }
         } else {
           showAlert('info', 'Unable to Fetch Chats', 'Please try again later.');

--- a/src/screens/UnreadChats/UnreadChats.tsx
+++ b/src/screens/UnreadChats/UnreadChats.tsx
@@ -1,0 +1,169 @@
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useCallback, useState } from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import EncryptedStorage from 'react-native-encrypted-storage';
+import { useDispatch } from 'react-redux';
+
+import { useTranslation } from 'react-i18next';
+import { ChatBox } from '../../components/ChatBox/ChatBox';
+import { numberNameIndex } from '../../helpers/nameNumberIndex';
+import { normalise } from '../../helpers/normalisePhoneNumber';
+import { getAllChats } from '../../services/GetAllChats';
+import { messageDecryption } from '../../services/MessageDecryption';
+import { hide } from '../../store/slices/loadingSlice';
+import { logout } from '../../store/slices/loginSlice';
+import {
+  setAlertMessage,
+  setAlertTitle,
+  setAlertType,
+  setAlertVisible,
+} from '../../store/slices/registrationSlice';
+import { setUnreadCount } from '../../store/slices/unreadChatSlice';
+import { useThemeColors } from '../../themes/colors';
+import { NavigationProps, UnreadStacKProps } from '../../types/usenavigation.type';
+import { getStyles } from '../AllChats/AllChats.styles';
+export interface Chat {
+  chatId: string;
+  contactName: string | null;
+  contactProfilePic: string | null;
+  lastMessageStatus: 'sent' | 'delivered' | 'read';
+  lastMessageText: string;
+  lastMessageTimestamp: string;
+  lastMessageType: 'sentMessage' | 'receivedMessage';
+  phoneNumber: string;
+  unreadCount: number;
+  publicKey: string;
+}
+
+type ContactNameMap = Record<string, string>;
+
+export const UnreadChats = () => {
+  const { t } = useTranslation('home');
+  const navigation = useNavigation<NavigationProps>();
+  const unreadStackNavigation = useNavigation<UnreadStacKProps>();
+  const dispatch = useDispatch();
+  const colors = useThemeColors();
+  const styles = getStyles(colors);
+
+  const [chats, setChats] = useState<Chat[]>([]);
+  const [contactNameMap, setContactNameMap] = useState<ContactNameMap>({});
+
+  const showAlert = useCallback(
+    (type: string, title: string, message: string) => {
+      dispatch(setAlertType(type));
+      dispatch(setAlertTitle(title));
+      dispatch(setAlertMessage(message));
+      dispatch(setAlertVisible(true));
+    },
+    [dispatch],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      const fetchChats = async () => {
+        const phoneNameMap = await numberNameIndex();
+        if (phoneNameMap === null) {
+          dispatch(logout());
+          showAlert('error', 'Session Expired', 'Please login again.');
+          await EncryptedStorage.clear();
+          setTimeout(() => {
+            dispatch(setAlertVisible(false));
+            navigation.replace('login');
+          }, 1000);
+          return;
+        }
+
+        setContactNameMap(phoneNameMap as ContactNameMap);
+
+        const response = await getAllChats();
+
+        if (response.status === 401 || response.data === null) {
+          dispatch(logout());
+          showAlert('error', 'Session Expired', 'Please login again.');
+          await EncryptedStorage.clear();
+          setTimeout(() => {
+            dispatch(setAlertVisible(false));
+            navigation.replace('login');
+          }, 1000);
+        } else if (response.status === 200 && response.data) {
+          const privateKey = await EncryptedStorage.getItem('privateKey');
+          if (privateKey) {
+            for (const chat of response.data.chats) {
+              try {
+                const decryptedMessage = await messageDecryption({
+                  encryptedMessage: chat.lastMessageText,
+                  myPrivateKey: privateKey,
+                  senderPublicKey: chat.publicKey,
+                });
+                chat.lastMessageText = decryptedMessage;
+              } catch (error) {
+                dispatch(hide());
+              }
+            }
+
+            const allChats = response.data.chats;
+            const unreadChats = allChats.filter((chat: { unreadCount: number; }) => chat.unreadCount > 0);
+
+            setChats(unreadChats);
+
+            const totalUnread = unreadChats.reduce(
+              (sum: number, chat: { unreadCount: number; }) => sum + (chat.unreadCount || 0),
+              0,
+            );
+            dispatch(setUnreadCount(totalUnread));
+          }
+        } else {
+          showAlert('info', 'Unable to Fetch Chats', 'Please try again later.');
+        }
+      };
+
+      fetchChats();
+    }, [dispatch, navigation, showAlert]),
+  );
+
+  return (
+    <View style={styles.container}>
+      <ScrollView style={styles.chatsContainer}>
+        {chats.length === 0 ? (
+          <View style={styles.noMessagesContainer}>
+            <Text style={styles.unreadtext}>
+              {t('EmptyUnreadMessage')}
+            </Text>
+          </View>
+        ) : (
+          chats.map(chat => (
+            <TouchableOpacity
+              key={chat.chatId}
+              onPress={() =>
+                unreadStackNavigation.navigate('individualChat', {
+                  user: {
+                    name:
+                      contactNameMap[normalise(chat.phoneNumber)] ||
+                      chat.phoneNumber,
+                    profilePicture: chat.contactProfilePic,
+                    phoneNumber: chat.phoneNumber,
+                    isBlocked: false,
+                    publicKey: chat.publicKey,
+                    onBlockStatusChange: () => { },
+                  },
+                })
+              }>
+              <ChatBox
+                image={chat.contactProfilePic}
+                name={
+                  contactNameMap[normalise(chat.phoneNumber)] ||
+                  chat.phoneNumber
+                }
+                description={chat.lastMessageText}
+                timestamp={chat.lastMessageTimestamp}
+                unreadCount={chat.unreadCount}
+                status={chat.lastMessageStatus}
+              />
+            </TouchableOpacity>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+

--- a/src/types/usenavigation.type.ts
+++ b/src/types/usenavigation.type.ts
@@ -1,4 +1,4 @@
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { UserDetails } from './user.types';
 
 type RootStackParamList = {
@@ -41,11 +41,21 @@ export type InitialStackProps = NativeStackNavigationProp<
 >;
 export type HomeStackParamList = {
   home: undefined;
-  individualChat: {user: UserDetails};
+  individualChat: { user: UserDetails };
   contacts: undefined;
 };
 export type HomeStackProps = NativeStackNavigationProp<
   HomeStackParamList,
   'home',
+  'individualChat'
+>;
+
+export type UnreadStackParamList = {
+  unread: undefined,
+  individualChat: { user: UserDetails };
+}
+export type UnreadStacKProps = NativeStackNavigationProp<
+  UnreadStackParamList,
+  'unread',
   'individualChat'
 >;


### PR DESCRIPTION
**This PR Implements the UnreadScreen of the following.**

- Add an unread chats, timestamps, badge, description, username, and profile image.

- It filters the unread chats renders in the particular screen with the count of unread messages in a badge component.

- Added an unread chats styles. 

- Add an unread stacks params list.

✅ Test:

- All components are tested using jest. All test cases passed and app works as expected. 

✅ Output images: 

<img src="https://github.com/user-attachments/assets/c05f9491-b01f-4220-84f8-c4a6512344ea" width= 200/>


