### PR TITLE
Fix translation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: QuickChat-frontend CI/CD
 on:
   push:
     branches:
-      - fix-translation-warnings
+      - main
 
 jobs:
   lint-and-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,7 @@ name: QuickChat-frontend CI/CD
 on:
   push:
     branches:
-      - main
-      - update-splash-screen-android
+      - fix-translation-warnings
 
 jobs:
   lint-and-test:

--- a/src/i18n/translations/english/auth.json
+++ b/src/i18n/translations/english/auth.json
@@ -19,5 +19,10 @@
   "Something went wrong while login": "Something went wrong while login",
   "Something went wrong": "Something went wrong",
   "Phone number required!": "Phone number required!",
-  "Type a message..": "Type a message.."
+  "Type a message..": "Type a message..",
+  "Start messages text": "One message. Infinite possibilities.",
+  "User friendly question": "What are you waiting for?",
+  "Profile Screen": "Profile",
+  "Edit Profile": "Edit Profile",
+  "Save": "Save"
 }

--- a/src/i18n/translations/english/contact.json
+++ b/src/i18n/translations/english/contact.json
@@ -6,5 +6,6 @@
   "Invite to Quick Chat": "Invite to Quick Chat",
   "It's good to see that, all of your contacts are on Quick Chat.": "It's good to see that, all of your contacts are on Quick Chat.",
   "Error while fetching the contacts": "Error while fetching the contacts",
-  "Welcome to Quick Chat. Let's have fun with this chating app?": "Welcome to Quick Chat. Let's have fun with this chating app?"
+  "Welcome to Quick Chat. Let's have fun with this chating app?": "Welcome to Quick Chat. Let's have fun with this chating app?",
+  "Invite": "Invite"
 }

--- a/src/i18n/translations/english/home.json
+++ b/src/i18n/translations/english/home.json
@@ -3,6 +3,6 @@
     "Profile":"Profile",
     "Unread Chats":"Unread Chats",
     "Edit Profile":"Edit Profile",
-    "No messages yet? That just means the best one is about to be sent—by you!":"No messages yet? That just means the best one is about to be sent—by you!",
-    "EmptyUnreadMessage":"You are all caught up!\nNo unread messages."
+    "EmptyUnreadMessage":"You are all caught up!\nNo unread messages.",
+    "App Name": "Quick Chat"
 }

--- a/src/i18n/translations/telugu/home.json
+++ b/src/i18n/translations/telugu/home.json
@@ -4,6 +4,5 @@
     "Unread Chats":"చదవని చాట్‌లు",
     "Quick Chat":"క్విక్ చాట్",
     "Edit Profile":"ప్రొఫైల్ సవరించండి",
-    "No messages yet? That just means the best one is about to be sent—by you!":"ఇంకా ఒక్క మెసేజ్ కూడా లేదా? అద్భుతమైనదే నువ్వే పంపబోతున్నావేమో!",
     "EmptyUnreadMessage": "మీరు అన్నీ చదివారు!\nచదవని సందేశాలు లేవు."
 }

--- a/src/navigation/stack/InitialStacks.test.tsx
+++ b/src/navigation/stack/InitialStacks.test.tsx
@@ -167,8 +167,8 @@ describe('InitialStacks', () => {
     const {getByText} = renderWithProviders();
 
     await waitFor(() => {
-      expect(getByText('One message. Infinite possibilities.')).toBeTruthy();
-      expect(getByText('What are you waiting for?')).toBeTruthy();
+      expect(getByText('Start messages text')).toBeTruthy();
+      expect(getByText('User friendly question')).toBeTruthy();
     });
   });
 
@@ -206,8 +206,8 @@ describe('InitialStacks', () => {
         'refreshToken',
         'new-refresh-token',
       );
-      expect(getByText('One message. Infinite possibilities.')).toBeTruthy();
-      expect(getByText('What are you waiting for?')).toBeTruthy();
+      expect(getByText('Start messages text')).toBeTruthy();
+      expect(getByText('User friendly question')).toBeTruthy();
     });
   });
 

--- a/src/navigation/stack/ProfileStacks.tsx
+++ b/src/navigation/stack/ProfileStacks.tsx
@@ -15,7 +15,7 @@ export const ProfileStack = () => {
         name="profileScreen"
         component={Profile}
         options={{
-          title: t('Profile'),
+          title: t('Profile Screen'),
           headerShown: true,
           headerStyle: {
             backgroundColor: colors.background,

--- a/src/screens/AllChats/AllChats.test.tsx
+++ b/src/screens/AllChats/AllChats.test.tsx
@@ -201,9 +201,9 @@ describe('AllChats Component', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('One message. Infinite possibilities.'),
+        screen.getByText('Start messages text'),
       ).toBeTruthy();
-      expect(screen.getByText('What are you waiting for?')).toBeTruthy();
+      expect(screen.getByText('User friendly question')).toBeTruthy();
     });
   });
 
@@ -329,7 +329,7 @@ describe('AllChats Component', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('One message. Infinite possibilities.'),
+        screen.getByText('Start messages text'),
       ).toBeTruthy();
     });
   });

--- a/src/screens/EditProfile/EditProfile.tsx
+++ b/src/screens/EditProfile/EditProfile.tsx
@@ -64,7 +64,7 @@ export const EditProfile = () => {
   const colors = useThemeColors();
   const profileNavigation = useNavigation<ProfileScreenNavigationProp>();
   const styles = getStyles(colors);
-  const {t} = useTranslation(['home', 'auth']);
+  const {t} = useTranslation(['auth']);
   const dispatch = useDispatch();
   const imageUri = useSelector(
     (state: RootState) => state.registration.imageUri,

--- a/src/screens/Home/Home.test.tsx
+++ b/src/screens/Home/Home.test.tsx
@@ -25,8 +25,8 @@ describe('Home Screen Tests', () => {
   });
   it('renders the description', () => {
     const { getByText } = render(<Home />);
-    expect(getByText('One message. Infinite possibilities.')).toBeTruthy();
-    expect(getByText('What are you waiting for?')).toBeTruthy();
+    expect(getByText('Start messages text')).toBeTruthy();
+    expect(getByText('User friendly question')).toBeTruthy();
   });
   it('render the plus-image icon', () => {
     render(< Home />);

--- a/src/screens/Home/Home.tsx
+++ b/src/screens/Home/Home.tsx
@@ -35,10 +35,10 @@ export const Home = () => {
         source={require('./../../assets/homescreen.png')}
       />
       <Text style={styles.description}>
-        {t('One message. Infinite possibilities.')}
+        {t('Start messages text')}
       </Text>
       <Text style={styles.description}>
-        {t('What are you waiting for?')}
+        {t('User friendly question')}
       </Text>
     </View>
     <View style={styles.plusContainer}>

--- a/src/screens/UnreadChats/UnreadChats.tsx
+++ b/src/screens/UnreadChats/UnreadChats.tsx
@@ -52,7 +52,7 @@ export const UnreadChats = () => {
   const {msgCount} = useSelector((state: RootState) => state.unread);
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerTitle: t('Quick Chat'),
+      headerTitle: t('App Name'),
       headerTitleAlign: 'center',
       headerStyle: {
         backgroundColor: colors.background,


### PR DESCRIPTION
## This PR fixed the missing translation key warnings all over the app.

- Added the missing translation keys to the translation files.
- Modified the screens accordingly and expected the translated keys in the test cases.

### General checks

- All the test cases passed locally and app is working as expected.
