### PR TITLE
Mandate Email During Registration & Remove Email from Edit Profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,7 @@ name: QuickChat-frontend CI/CD
 on:
   push:
     branches:
-      - main
-      - fix-push-notifications-bugs
-      - fix-message-status
+      - mandate-email
 
 jobs:
   lint-and-test:

--- a/src/screens/EditProfile/EditProfile.test.tsx
+++ b/src/screens/EditProfile/EditProfile.test.tsx
@@ -92,7 +92,6 @@ describe('EditProfile Component', () => {
     await waitFor(() => {
       expect(getByText('First Name')).toBeTruthy();
       expect(getByText('Last Name')).toBeTruthy();
-      expect(getByText('Email')).toBeTruthy();
       expect(getByText('Save')).toBeTruthy();
     });
   });
@@ -108,38 +107,12 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), '');
     fireEvent.changeText(getByDisplayValue('user'), '');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'testuser@gmail.com',
-    );
 
     fireEvent.press(getByText('Save'));
 
     await waitFor(() => {
       expect(getByText('First name required!')).toBeTruthy();
       expect(getByText('Last name required!')).toBeTruthy();
-    });
-  });
-
-  test('shows alert for invalid email format', async () => {
-    const {getByText, getByDisplayValue} = render(
-      <Provider store={store}>
-        <EditProfile />
-      </Provider>,
-    );
-    await waitFor(() => getByText('Save'));
-
-    fireEvent.changeText(getByDisplayValue('test'), 'test1');
-    fireEvent.changeText(getByDisplayValue('user'), 'user1');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'invalid@email.',
-    );
-
-    fireEvent.press(getByText('Save'));
-
-    await waitFor(() => {
-      expect(getByText('Invalid email format!')).toBeTruthy();
     });
   });
 
@@ -153,10 +126,6 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), 'test1');
     fireEvent.changeText(getByDisplayValue('user'), '');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'testuser@gmail.com',
-    );
 
     fireEvent.press(getByText('Save'));
 
@@ -199,10 +168,6 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), 'test1');
     fireEvent.changeText(getByDisplayValue('user'), 'user1');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'testuser@gmail.com',
-    );
 
     fireEvent.press(getByText('Save'));
 
@@ -238,10 +203,6 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), 'test1');
     fireEvent.changeText(getByDisplayValue('user'), 'user1');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'testuser1@gmail.com',
-    );
 
     fireEvent.press(getByText('Save'));
 
@@ -252,7 +213,7 @@ describe('EditProfile Component', () => {
           image: '',
           firstName: 'test1',
           lastName: 'user1',
-          email: 'testuser1@gmail.com',
+          email: 'testuser@gmail.com',
           token: 'mock-token',
         },
         expect.any(Object),
@@ -278,10 +239,6 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), 'test1');
     fireEvent.changeText(getByDisplayValue('user'), 'user1');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'test1@example.com',
-    );
 
     fireEvent.press(getByText('Save'));
 
@@ -307,10 +264,6 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), 'test1');
     fireEvent.changeText(getByDisplayValue('user'), 'user1');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'test1@example.com',
-    );
 
     fireEvent.press(getByText('Save'));
 
@@ -334,10 +287,6 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), '');
     fireEvent.changeText(getByDisplayValue('user'), 'user1');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'testuser1@gmail.com',
-    );
 
     fireEvent.press(getByText('Save'));
     await waitFor(() => {
@@ -562,7 +511,6 @@ describe('EditProfile Component', () => {
     await waitFor(() => {
       expect(getByText('First Name')).toBeTruthy();
       expect(getByText('Last Name')).toBeTruthy();
-      expect(getByText('Email')).toBeTruthy();
     });
   });
 
@@ -591,10 +539,6 @@ describe('EditProfile Component', () => {
 
     fireEvent.changeText(getByDisplayValue('test'), 'test1');
     fireEvent.changeText(getByDisplayValue('user'), 'user1');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'testuser1@gmail.com',
-    );
 
     fireEvent.press(getByText('Save'));
 
@@ -643,12 +587,9 @@ describe('EditProfile Component', () => {
     );
 
     await waitFor(() => getByText('Save'));
-    fireEvent.changeText(getByDisplayValue('test'), 'test');
-    fireEvent.changeText(getByDisplayValue('user'), 'user');
-    fireEvent.changeText(
-      getByDisplayValue('testuser@gmail.com'),
-      'test@example.com',
-    );
+    fireEvent.changeText(getByDisplayValue('test'), 'test1');
+    fireEvent.changeText(getByDisplayValue('user'), 'user1');
+
     fireEvent.press(getByText('Save'));
 
     await waitFor(() => {

--- a/src/screens/EditProfile/EditProfile.tsx
+++ b/src/screens/EditProfile/EditProfile.tsx
@@ -93,7 +93,7 @@ export const EditProfile = () => {
     profilePicture: string;
     firstName: string;
     lastName: string;
-    email?: string;
+    email: string;
     token: string;
   }>();
 
@@ -125,7 +125,7 @@ export const EditProfile = () => {
         setEditProfileForm({key: 'lastName', value: userData.lastName || ''}),
       );
       dispatch(
-        setEditProfileForm({key: 'email', value: userData.email || null}),
+        setEditProfileForm({key: 'email', value: userData.email || ''}),
       );
       dispatch(
         setEditProfileForm({
@@ -139,7 +139,7 @@ export const EditProfile = () => {
       setInitialValues({
         firstName: userData.firstName || '',
         lastName: userData.lastName || '',
-        email: userData.email || null,
+        email: userData.email || '',
         phoneNumber: userData.phoneNumber || '',
         token: AccessToken,
         image: initialImage,
@@ -163,8 +163,6 @@ export const EditProfile = () => {
     });
   }, [profileNavigation, renderHeaderLeft]);
 
-  const validateEmail = (email: string) =>
-    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
   const validateForm = () => {
     const newErrors: Partial<typeof editProfileForm> = {};
@@ -175,10 +173,6 @@ export const EditProfile = () => {
     }
     if (!editProfileForm.lastName) {
       newErrors.lastName = 'Last name required!';
-      isValid = false;
-    }
-    if (editProfileForm.email && !validateEmail(editProfileForm.email)) {
-      newErrors.email = 'Invalid email format!';
       isValid = false;
     }
     dispatch(setErrors(newErrors));
@@ -245,10 +239,6 @@ export const EditProfile = () => {
       key: 'lastName',
       title: 'Last Name',
     },
-    {
-      key: 'email',
-      title: 'Email',
-    },
   ] as const;
   const renderedImage =
     imageUri || user?.profilePicture || DEFAULT_PROFILE_IMAGE;
@@ -261,7 +251,6 @@ export const EditProfile = () => {
     return (
       initialValues.firstName !== editProfileForm.firstName ||
       initialValues.lastName !== editProfileForm.lastName ||
-      initialValues.email !== editProfileForm.email ||
       imageChanged
     );
   }, [initialValues, editProfileForm, editedImage]);

--- a/src/screens/Registration/Registration.test.tsx
+++ b/src/screens/Registration/Registration.test.tsx
@@ -118,7 +118,7 @@ describe('Registration Screen', () => {
     expect(getByPlaceholderText('Phone number')).toBeTruthy();
     expect(getByPlaceholderText('Password')).toBeTruthy();
     expect(getByPlaceholderText('Confirm Password')).toBeTruthy();
-    expect(getByPlaceholderText('Email (Optional)')).toBeTruthy();
+    expect(getByPlaceholderText('Email')).toBeTruthy();
     expect(getByText('Register')).toBeTruthy();
     expect(getByText('Sign in')).toBeTruthy();
   });
@@ -185,7 +185,7 @@ describe('Registration Screen', () => {
   it('shows invalid email error', async () => {
     const {getByPlaceholderText, getByText} = renderComponent();
     fireEvent.changeText(
-      getByPlaceholderText('Email (Optional)'),
+      getByPlaceholderText('Email'),
       'invalid-email',
     );
     fireEvent.press(getByText('Register'));
@@ -225,7 +225,7 @@ describe('Registration Screen', () => {
       'Password@123',
     );
     fireEvent.changeText(
-      getByPlaceholderText('Email (Optional)'),
+      getByPlaceholderText('Email'),
       'testuser@gmail.com',
     );
 
@@ -252,7 +252,7 @@ describe('Registration Screen', () => {
       'Password@123',
     );
     fireEvent.changeText(
-      getByPlaceholderText('Email (Optional)'),
+      getByPlaceholderText('Email'),
       'user@gmail.com',
     );
 
@@ -283,7 +283,7 @@ describe('Registration Screen', () => {
       'Password@123',
     );
     fireEvent.changeText(
-      getByPlaceholderText('Email (Optional)'),
+      getByPlaceholderText('Email'),
       'user@gmail.com',
     );
 
@@ -315,7 +315,7 @@ describe('Registration Screen', () => {
       'Password@123',
     );
     fireEvent.changeText(
-      getByPlaceholderText('Email (Optional)'),
+      getByPlaceholderText('Email'),
       'user@gmail.com',
     );
 
@@ -346,7 +346,7 @@ describe('Registration Screen', () => {
       'Password@123',
     );
     fireEvent.changeText(
-      getByPlaceholderText('Email (Optional)'),
+      getByPlaceholderText('Email'),
       'user@gmail.com',
     );
 
@@ -368,7 +368,7 @@ describe('Registration Screen', () => {
     expect(getByPlaceholderText('Last Name')).toBeTruthy();
     expect(getByPlaceholderText('Password')).toBeTruthy();
     expect(getByPlaceholderText('Confirm Password')).toBeTruthy();
-    expect(getByPlaceholderText('Email (Optional)')).toBeTruthy();
+    expect(getByPlaceholderText('Email')).toBeTruthy();
   });
 
   it('updates form value in Redux store on input change', async () => {

--- a/src/screens/Registration/Registration.tsx
+++ b/src/screens/Registration/Registration.tsx
@@ -196,7 +196,7 @@ export const Registration = () => {
     {key: 'lastName', title: 'Last Name'},
     {key: 'password', title: 'Password', secure: true},
     {key: 'confirmPassword', title: 'Confirm Password', secure: true},
-    {key: 'email', title: 'Email (Optional)'},
+    {key: 'email', title: 'Email'},
   ] as const;
 
   return (

--- a/src/services/RegisterUser.ts
+++ b/src/services/RegisterUser.ts
@@ -9,7 +9,7 @@ export const registerUser = async (
     lastName: string;
     phoneNumber: string;
     password: string;
-    email: string | null;
+    email: string;
   },
   keys: {
     publicKey: string;
@@ -27,7 +27,7 @@ export const registerUser = async (
     firstName: payload.firstName.trim(),
     lastName: payload.lastName.trim(),
     profilePicture: payload.image,
-    email: payload.email?.trim() || null,
+    email: payload.email.trim(),
     password: payload.password,
     publicKey: keys.publicKey,
     privateKey: encryptedPrivateKey,

--- a/src/services/__tests__/RegisterUser.test.ts
+++ b/src/services/__tests__/RegisterUser.test.ts
@@ -140,45 +140,4 @@ describe('registerUser', () => {
       'Network Error',
     );
   });
-
-  it('should handle null email and fallback to null in payload', async () => {
-    const payloadWithNullEmail = {
-      ...payload,
-      email: null,
-    };
-
-    const encryptedPrivateKey = await keyEncryption({
-      privateKey: keys.privateKey,
-      password: payload.password,
-    });
-
-    const expectedUserData = {
-      phoneNumber: payload.phoneNumber,
-      firstName: payload.firstName.trim(),
-      lastName: payload.lastName.trim(),
-      profilePicture: payload.image,
-      email: null,
-      password: payload.password,
-      publicKey: keys.publicKey,
-      privateKey: encryptedPrivateKey,
-      deviceId: deviceId.deviceId,
-      fcmToken: 'mocked-token',
-    };
-
-    mockedFetch.mockResolvedValueOnce({
-      status: 201,
-      json: jest.fn().mockResolvedValue({success: true}),
-    });
-
-    const result = await registerUser(payloadWithNullEmail, keys, deviceId);
-
-    expect(mockedFetch).toHaveBeenCalledWith(`${API_URL}/api/users`, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify(expectedUserData),
-    });
-
-    expect(result.status).toBe(201);
-    expect(result.data).toEqual({success: true});
-  });
 });


### PR DESCRIPTION
This PR introduces the following changes:

- Email field is now mandatory during the user registration process.
- Removed the email field from the user edit profile screen.
- Updated relevant test cases.

Thank you. ☺️ 

